### PR TITLE
Add nil guards

### DIFF
--- a/lib/lib_lat_lon/data/coords.ex
+++ b/lib/lib_lat_lon/data/coords.ex
@@ -208,8 +208,21 @@ defmodule LibLatLon.Coords do
     end
   end
 
-  def borrow(%Exexif.Data.Gps{gps_latitude: lat, gps_longitude: lon}) do
-    %LibLatLon.Coords{lat: borrow(lat), lon: borrow(lon)}
+  def borrow(%Exexif.Data.Gps{
+        gps_latitude: lat,
+        gps_latitude_ref: lat_ref,
+        gps_longitude: lon,
+        gps_longitude_ref: lon_ref,
+        gps_img_direction: dir,
+        gps_img_direction_ref: dir_ref
+      }) do
+    with %LibLatLon.Coords{} = coords <- borrow({{lat, lat_ref}, {lon, lon_ref}}) do
+      %LibLatLon.Coords{
+        coords
+        | direction: dir,
+          magnetic?: dir_ref == "M"
+      }
+    end
   end
 
   def borrow({lat, lon}), do: %LibLatLon.Coords{lat: borrow(lat), lon: borrow(lon)}

--- a/lib/lib_lat_lon/data/coords.ex
+++ b/lib/lib_lat_lon/data/coords.ex
@@ -208,6 +208,10 @@ defmodule LibLatLon.Coords do
     end
   end
 
+  def borrow(%Exexif.Data.Gps{gps_latitude: lat, gps_longitude: lon}) do
+    %LibLatLon.Coords{lat: borrow(lat), lon: borrow(lon)}
+  end
+
   def borrow({lat, lon}), do: %LibLatLon.Coords{lat: borrow(lat), lon: borrow(lon)}
   def borrow(shit), do: {:error, {:weird_input, shit}}
 

--- a/lib/lib_lat_lon/data/coords.ex
+++ b/lib/lib_lat_lon/data/coords.ex
@@ -196,7 +196,8 @@ defmodule LibLatLon.Coords do
         gps_longitude_ref: lon_ref,
         gps_img_direction: dir,
         gps_img_direction_ref: dir_ref
-      }) do
+      })
+      when not is_nil(alt) and not is_nil(alt_ref) do
     with %LibLatLon.Coords{} = coords <- borrow({{lat, lat_ref}, {lon, lon_ref}}) do
       %LibLatLon.Coords{
         coords


### PR DESCRIPTION
I was having some issues with some images that had GPS coordinates but had `nil` for both `gps_altitude` and `gps_altitude_ref` keys, thus throwing an arithmetic error when doing `nil * nil`