### PR TITLE
Use runtime instead of compile time configuration

### DIFF
--- a/lib/lib_lat_lon.ex
+++ b/lib/lib_lat_lon.ex
@@ -6,12 +6,6 @@ defmodule LibLatLon do
   There is a single function exported: [`LibLatLon.lookup/3`].
   """
 
-  @default_provider Application.compile_env(
-                      :lib_lat_lon,
-                      :provider,
-                      LibLatLon.Providers.OpenStreetMap
-                    )
-
   @doc """
   Pass anything to lookup using default provider and with default options.
   Pass a provider as the second argument to use a specific provider.
@@ -38,7 +32,7 @@ defmodule LibLatLon do
 
   """
   @spec lookup(any(), atom(), %{}) :: {:ok, LibLatLon.Info.t()} | {:error, any()}
-  def lookup(value, provider \\ @default_provider, opts \\ %{}) do
+  def lookup(value, provider \\ default_provider(), opts \\ %{}) do
     case guess_lookup(provider, value, opts) do
       {:ok, result} -> result
       anything -> anything
@@ -99,5 +93,13 @@ defmodule LibLatLon do
       end)
       |> Enum.into(%{})
     end
+  end
+
+  defp default_provider() do
+    Application.get_env(
+      :lib_lat_lon,
+      :provider,
+      LibLatLon.Providers.OpenStreetMap
+    )
   end
 end

--- a/lib/lib_lat_lon/providers/google_maps.ex
+++ b/lib/lib_lat_lon/providers/google_maps.ex
@@ -6,12 +6,11 @@ defmodule LibLatLon.Providers.GoogleMaps do
   @behaviour LibLatLon.Provider
 
   @server_url "https://maps.googleapis.com"
-  @key Application.compile_env(:lib_lat_lon, :google_maps_api_key, nil)
 
   @search Enum.join([@server_url, "maps/api/geocode/json"], "/")
   @reverse Enum.join([@server_url, "maps/api/geocode/json"], "/")
 
-  @defaults %{language: "en", key: @key}
+  @defaults %{language: "en"}
 
   @doc false
   def name, do: "Google Maps"
@@ -50,7 +49,7 @@ defmodule LibLatLon.Providers.GoogleMaps do
   ##############################################################################
 
   defp defaults do
-    Map.put(@defaults, :key, System.get_env("GOOGLE_MAPS_API_KEY") || @key)
+    Map.put(@defaults, :key, System.get_env("GOOGLE_MAPS_API_KEY") || Application.get_env(:lib_lat_lon, :google_maps_api_key, nil))
   end
 
   # %{


### PR DESCRIPTION
If you are compile your application in an environment that doesn't have access to secrets, LibLatLon will error out on the calls to `Application.compile_env`:

```
ERROR! the application :lib_lat_lon has a different value set for key :google_maps_api_key during runtime compared to compile time. Since this application environment entry was marked as compile time, this difference can lead to different behaviour than expected: metadata 
```

This PR is following the Elixir library guidelines [here](https://hexdocs.pm/elixir/1.13/library-guidelines.html#avoid-compile-time-application-configuration).

Some more good info on config here: https://felt.com/blog/elixir-configuration